### PR TITLE
lisätty suosikkilistan URL:n kopiointi ja listan näyttö

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8000
+VITE_BASE_URL=http://localhost:5173

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,7 @@ import { GroupDetailsPage } from "./pages/GroupDetailsPage";
 import { ShowtimesPage } from "./pages/ShowtimesPage";
 import { CreateGroupPage } from "./pages/CreateGroupPage";
 import ReviewsPage from "./pages/ReviewsPage/ReviewsPage.jsx";
+import { SharedFavoritesPage } from "./pages/SharedFavoritesPage";
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ export default function App() {
             <Route path="theaters" element={<ShowtimesPage />} />
             <Route path="create-group" element={<CreateGroupPage />} />
             <Route path="reviews" element={<ReviewsPage />} />
+            <Route path="shared-favorites/:listId" element={<SharedFavoritesPage />} />
             <Route path="*" element={<div>Not Found</div>} />
           </Route>
         </Routes>

--- a/client/src/components/UserFavorites/UserFavorites.jsx
+++ b/client/src/components/UserFavorites/UserFavorites.jsx
@@ -2,36 +2,39 @@ import { useEffect, useState } from "react";
 import { MovieCard } from "../../components/MovieCard";
 import { Carousel } from "@mantine/carousel";
 import useAuth from "../../hooks/useAuth";
-import { Button } from "@mantine/core";
+import { Button, ActionIcon, Tooltip, rem, Group } from "@mantine/core";
 import { getFavorites } from "../../data/favorites.js";
+import { IconCopy, IconCheck } from "@tabler/icons-react";
+import { showNotification } from "@mantine/notifications";
 
 export default function UserFavorites() {
-  const { username } = useAuth();
-
+  const { username, userId } = useAuth();
   const [favorites, setFavorites] = useState(null);
+  const listId = userId;
+  const baseUrl = import.meta.env.VITE_BASE_URL;
+  const shareLink = `${baseUrl}/shared-favorites/${listId}`;
 
   useEffect(() => {
     fetchFavorites();
   }, []);
 
-
   const fetchFavorites = async () => {
     try {
       const result = await getFavorites(username);
       // Muutetaan data ennen tilaan tallentamista
-      const modifiedMedia = result.map(media => ({
+      // (MovieCard - komponentti odottaa "media_type", "poster_path" ja "id" - kenttiä)
+      const modifiedMedia = result.map((media) => ({
         ...media,
-        media_type: media.type, // muutetaan "type" -> "media_type"
-        poster_path: media.poster_url, // muutetaan "poster_url" -> "poster_path"
-        id: media.tmdb_id, // muutetaan "tmdb_id" -> "id"
+        media_type: media.type,
+        poster_path: media.poster_url,
+        id: media.tmdb_id,
       }));
-      // sarjat ja leffat erilleen
       setFavorites(modifiedMedia);
     } catch (error) {
       console.error(error);
     }
   };
-  
+
   // If not null, map favorites
   const favoritesSlide = favorites
     ? favorites.map((entry) => (
@@ -41,9 +44,33 @@ export default function UserFavorites() {
       ))
     : null;
 
+  const copyUrlButton = (
+    <Tooltip label="Copy favorites list URL">
+      <ActionIcon
+        size={42}
+        variant="transparent"
+        onClick={() => {
+          navigator.clipboard.writeText(shareLink);
+          showNotification({
+            title: "Copied!",
+            message: "Favorites list URL has been copied to clipboard.",
+            color: "green",
+            icon: <IconCheck />,
+            autoClose: 2000,
+          });
+        }}
+      >
+        <IconCopy style={{ width: rem(24), height: rem(24) }} />
+      </ActionIcon>
+    </Tooltip>
+  );
+
   return (
     <>
-      <h3>Your favorites:</h3>
+      <Group justify="space-between">
+        <h3>Your favorites:</h3>
+        {copyUrlButton}
+      </Group>
       <Carousel
         slideSize={{ base: "33.333%", sm: "20%" }}
         slideGap={{ base: "md", sm: "xl" }}

--- a/client/src/components/UserFavorites/UserFavorites.jsx
+++ b/client/src/components/UserFavorites/UserFavorites.jsx
@@ -12,6 +12,7 @@ export default function UserFavorites() {
   const [favorites, setFavorites] = useState(null);
   const listId = userId;
   const baseUrl = import.meta.env.VITE_BASE_URL;
+  // const baseUrl = import.meta.env.BASE_URL
   const shareLink = `${baseUrl}/shared-favorites/${listId}`;
 
   useEffect(() => {

--- a/client/src/data/favorites.js
+++ b/client/src/data/favorites.js
@@ -5,6 +5,11 @@ export async function getFavorites(username) {
   return response.data;
 }
 
+export async function getFavoritesByListId(listId) {
+  const response = await api.get(`/users/favorites/${listId}`);
+  return response.data;
+}
+
 export async function addFavorite(username, title, type, description, tmdbId, posterUrl) {
   return api.post(`/users/${username}/favorites`, {
     username,

--- a/client/src/pages/SharedFavoritesPage/SharedFavoritesPage.jsx
+++ b/client/src/pages/SharedFavoritesPage/SharedFavoritesPage.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { MovieCard } from "../../components/MovieCard/index.js";
+import { useParams } from "react-router-dom";
+import { Button, Container, Space, Grid, } from "@mantine/core";
+import { getFavoritesByListId } from "../../data/favorites.js";
+
+export default function SharedFavoritesPage() {
+  const { listId } = useParams();
+
+  const [favorites, setFavorites] = useState(null);
+  const [sharedBy, setSharedBy] = useState(null);
+
+  useEffect(() => {
+
+    (async () => {
+      await fetchFavorites();
+    })();
+  }, []);
+
+  const fetchFavorites = async () => {
+    try {
+      const result = await getFavoritesByListId(listId);
+      // Muutetaan data ennen tilaan tallentamista 
+      // (MovieCard - komponentti odottaa "media_type", "poster_path" ja "id" - kenttiä)
+      const modifiedMedia = result.map((media) => ({
+        ...media,
+        media_type: media.type, 
+        poster_path: media.poster_url,
+        id: media.tmdb_id,
+      }));
+      setFavorites(modifiedMedia);
+      setSharedBy(modifiedMedia[0].shared_by);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const favoritesGrid = favorites
+    ? favorites.map((entry) => (
+        <Grid.Col span={{ base: 4, md: 4, lg: 3 }} key={entry.id}>
+          <MovieCard movie={entry} />
+        </Grid.Col>
+      ))
+    : null;
+
+
+  return (
+    <Container size="lg">
+      <h3>{ sharedBy }'s favorites:</h3>
+      <Grid mt="xl">
+        {favoritesGrid}
+      </Grid>
+    </Container>
+  );
+}

--- a/client/src/pages/SharedFavoritesPage/index.js
+++ b/client/src/pages/SharedFavoritesPage/index.js
@@ -1,0 +1,3 @@
+import SharedFavoritesPage from "./SharedFavoritesPage.jsx";
+
+export { SharedFavoritesPage };

--- a/server/models/users_model.js
+++ b/server/models/users_model.js
@@ -61,6 +61,17 @@ const userModel = {
 
     return result.rowCount > 0 ? result.rows : null;
   },
+  getFavoritesByListId: async function (listId) {
+    const result = await dbPool.query(
+      `SELECT media.*, users.username AS shared_by
+       FROM media
+       JOIN favorites USING (media_id)
+       JOIN users USING (user_id)
+       WHERE favorites.user_id=$1`,
+      [listId],
+    );
+    return result.rowCount > 0 ? result.rows : null;
+  },
 
   getReviews: async function (username) {
     const result = await dbPool.query(

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -168,6 +168,17 @@ router.get("/:username/favorites", async (req, res) => {
   }
 });
 
+router.get("/favorites/:listId", async (req, res) => {
+  try {
+    const { listId } = req.params;
+    const result = await userModel.getFavoritesByListId(listId);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).end();
+  }
+});
+
 router.get("/:username/reviews", async (req, res) => {
   try {
     const { username } = req.params;


### PR DESCRIPTION
Suosikkilistan linkin voi nyt kopioida profiilisivulta. 

Huomaa, että clientin .env -tiedostoa täytyy päivittää. Katso .env.example